### PR TITLE
Minor fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,14 +36,6 @@
 	       "Mark Davis",
 	       "CLDR Contributors"
 	 ]},
-    "I18N-GLOSSARY": {
-		title:    "Internationalization (I18N) Glossary",
-		href:     "https://www.w3.org/TR/i18n-glossary",
-		publisher: "W3C I18N WG",
-		authors: [
-		   "Richard Ishida"
-		   ]
-		}
      }
      };
 
@@ -175,7 +167,8 @@
               <ol>
 				  <li>Even simple locale fallback chains can require the client to search for or retrieve multiple files.
 				  <li>Because the files are separate, versioning of the content must be rigorously controlled. 
-				  <li>It may be necessary to test many more variations to ensure proper operation.</p>
+				  <li>It may be necessary to test many more variations to ensure proper operation.
+          </ol>
 		  </section>
 		  
 		  <section id="hybrid">


### PR DESCRIPTION
* Remove the custom `localBiblio` for `I18N-GLOSSARY` since ReSpec already knows it
* Markup fix


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/localizable-manifests/pull/6.html" title="Last updated on Jul 13, 2021, 3:47 AM UTC (05846e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/localizable-manifests/6/f7b00a6...05846e8.html" title="Last updated on Jul 13, 2021, 3:47 AM UTC (05846e8)">Diff</a>