### PR TITLE
Remove unnecessary localBiblio entries

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,23 +20,7 @@
           //previousPublishDate:  "2021-08-24",
 		  noRecTrack: true,
           group:  "i18n",
-          github: "w3c/localizable-manifests",
-
-    localBiblio:  {
-    "CLDR": {
-	    title:    "Common Locale Data Repository",
-	    href:     "http://cldr.unicode.org",
-        publisher:  "Unicode"
-    },
-    "LDML": {
-	    title:    "Unicode Technical Standard #35: Locale Data Markup Language",
-	    href:     "https://www.unicode.org/reports/tr35/",
-	    publisher: "Unicode",
-	    authors: [
-	       "Mark Davis",
-	       "CLDR Contributors"
-	 ]},
-     }
+          github: "w3c/localizable-manifests"
      };
 
     </script>


### PR DESCRIPTION
These `localBiblio` entries are not used in the document.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/localizable-manifests/pull/14.html" title="Last updated on Aug 18, 2023, 12:31 AM UTC (3eeaee1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/localizable-manifests/14/f61f6f4...3eeaee1.html" title="Last updated on Aug 18, 2023, 12:31 AM UTC (3eeaee1)">Diff</a>