### PR TITLE
Update following work with app-manifest at TPAC2023

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,9 +70,41 @@
           
           <p>Manifests need to match a user's language preference to the available localized resources. The user's locale preference can include more than just a primary language subtag. It might include the script (in tags such as <code>zh-Hans</code>, meaning "Chinese as written in the Simplified Han script") or region (in tags such as <code>fr-CA</code>, meaning "French as used in Canada")&mdash;or both. Some systems support <a>Unicode Locale Identifiers</a>, an extension to [[BCP47]] that includes tailoring such as calendars, number shaping, collation, and more. For more information, see [[LTLI]].</p>
           
-          <p>Matching localized resources to a user's locale preference usually involves "locale fallback", using a mechanism such as [[BCP47]]'s "lookup" matching scheme or [[CLDR]]'s "best match" scheme. These involve comparing the language tags on each resource seeking the <em>longest</em> tag that completely matches the user's preference. There is also, usually, a default locale to use for cases in which none of the localized resources match the user's preference.</p>
+          <section id="locale-fallback">
+			  <h4>Matching Language Tags and Locale Fallback</h4>
+			  
+              <p>Matching localized resources to a user's locale preference usually involves "locale fallback", using a mechanism such as [[BCP47]]'s "lookup" matching scheme or [[CLDR]]'s "best match" scheme. These involve comparing the language tags on each <a>resource</a> seeking the <em>longest</em> tag that completely matches the user's preference. There is also, usually, a default locale to use for cases in which none of the localized resources match the user's preference.</p>
+			  
+			  <p>Matching of language tags to available resources (such as found in [[[#path-vs-file]]]) or to items in some form of language map (see [[[#language-maps]]]) can require an implementation to examine all of the available values, as the first potential match might not be the best overall match.</p>
+			  
+			  <p>For example, consider the following language map:</p>
+			  
+			  <pre class="javascript">
+"localized-resource": {
+	"en":     {"value": "This is English"},
+	"en-GB":  {"value": "This is UK English"},
+	"en-US":  {"value": "This is US English"}
+}
+			  </pre>
+			  
+			  <p>If the user's locale preference were <code>en-GB</code> or <code>en-US</code>, the best match is included in the list. Obviously, the entire list must be read to find the best match, since the entry for <code>en</code> also matches either value.</p>
+			  
+			  <p>If the user's locale preference were <code>en-AE</code> (English as used in the United Arab Emirates), the best match in the list is <code>en</code>, although some implementations of best matching will apply out-of-band information to potentially match a longer tag.</p>
+			  
+			  <p>If the user's locale preference were <code>fr-FR</code> (French as used in France), none of the values match and some form of defaulting would be need to select the language to use.</p>
+			  
+			  <p>Finally, the user's locale preference could include additional subtags, such as those used to tailor locale setting or such as a language variant. An example of a tailored locale might be <code>en-US-u-hc-h23</code> (US English but with the "hour cycle" set to 24 hour time). For more information on CLDR locale extensions, see [[RFC6067]]. An example of a language variant might be <code>en-GB-oxendict</code> (UK English, but using spelling conventions of the Oxford English Dictionary).</p>
+			  
+			  <p>Locale fallback is implemented such that the user's preference is matched against the available list of values, and, if no exact match is found, removing the last subtag and repeating. This is described as "lookup" in the language tag matching part of [[BCP47]] (specifically [[RFC4647]]). Thus, the tag <code>en-GB-oxendict</code> would be compared against the above languge map as follows:</p>
+			  
+			  <pre>
+en-GB-oxendict  // no match
+en-GB           // matches en-GB
+en              // if en-GB were not present, matches en
+(default)       // no match, use defaults
+			  </pre>
+          </section>
           
-          <p class="issue">Include an example showing how fallback works so readers understand why matching requires looking at the complete collection of resources.</p>
       </section>
       </section>
       

--- a/index.html
+++ b/index.html
@@ -54,24 +54,30 @@
         
       </section>
       <section id="use-cases">
-		  <h2>Requirements and Use Cases</h2>
+		  <h2>Use Cases</h2>
 		  <p>There are different ways that manifest files might be used on the Web and these affect the choice of manifest localization strategy.</p> 
 
           <p><dfn data-lt="packaged" class="lint-ignore export">Packaged Manifest.</dfn> Some manifests are packaged with other files to form an application or document. Since the manifest is generally consumed as part of the larger set of content and the content is downloaded as a single unit, manifests of this type can use more modular localization strategies, such as using multiple files with names or paths based on the locale.</p>
           
           <p><dfn data-lt="shorthand" class="lint-ignore export">Shorthand Description Manifest.</dfn> Some manifests are meant to be used as a shorthand description of an application, document, or other resource. Manifests of this type are often downloaded by the client, sometimes as a precursor to retrieving the actual resource or its component parts. Since retrieving multiple files has latency, size, and storage implications, this type of manifest usually seeks to use a single file or other less-modular approaches.</p>
+      </section>
 
-          <p>Another consideration is the <a>language negotiation</a> strategy employed by the specification. If a manifest can be generated on demand (rather than being cached at a well-known URL), then the localization might be applied on a per-request basis. This points more toward a <a>shorthand</a> manifest style. In other cases, where some implementations might be able to negotiate while others cannot, it is important for the specification not to limit the choice and allow for various different mechanisms to be used.</p>
+      <section id="language-preferences">
+		  <h2>Managing Language Preferences</h2>
+		  
+          <p>Another consideration is the <a>language negotiation</a> strategy employed by the specification. If a manifest can be generated on demand (rather than being cached at a well-known URL), then the localization might be applied on a per-request basis. This points more toward a <a>shorthand</a> manifest style. In other cases, where some implementations might be able to negotiate while others cannot, it might be important for the specification to permit different strategies to be used.</p>
           
           <p>Bear in mind that modern operating environments support quite extensive sets of available locales and that application owners often wish to satisfy diverse audiences with a single localized application or document. While examples in specifications necessarily are constrained to perhaps three or four locales, actual applications with 50 or more specific locales are not uncommon.</p>
           
-          <p>In addition, users often have "overspecified" locales containing tailorings that match a given users local needs. Long locale identifiers, which are expressed as BCP47 language tags, sometimes need to be trimmed or have extensions removed when searching for localized resources (such as a manifest).</p>
+          <p>Manifests need to match a user's language preference to the available localized resources. The user's locale preference can include more than just a primary language subtag. It might include the script (in tags such as <code>zh-Hans</code>, meaning "Chinese as written in the Simplified Han script") or region (in tags such as <code>fr-CA</code>, meaning "French as used in Canada")&mdash;or both. Some systems support <a>Unicode Locale Identifiers</a>, an extension to [[BCP47]] that includes tailoring such as calendars, number shaping, collation, and more. For more information, see [[LTLI]].</p>
+          
+          <p>Matching localized resources to a user's locale preference usually involves "locale fallback", using a mechanism such as [[BCP47]]'s "lookup" matching scheme or [[CLDR]]'s "best match" scheme. These involve comparing the language tags on each resource seeking the <em>longest</em> tag that completely matches the user's preference. There is also, usually, a default locale to use for cases in which none of the localized resources match the user's preference.</p>
       </section>
       
       <section id="">
 		  <h2>Indicating Language and Direction</h2>
 		  
-		  <p>Natural language values stored in a manifest, like any document format or data structure, require language and direction metadata in order to be used by <a>consumers</a> successfully. For detailed information about the requirements, see [[STRING-META]].</p>
+		  <p><a>Natural language</a> values stored in a manifest, like any document format or data structure, require language and direction metadata in order to be used by <a>consumers</a> successfully. For detailed information about the requirements, see [[STRING-META]].</p>
 		  
 		  <p>There are four common serializations for string values in a manifest in the following sections. These are generally used together to form a complete localization solution.</p>
 		  
@@ -79,6 +85,7 @@
 			  <h4>Non-Linguistic Fields</h4>
 		  <p>For <a>non-linguistic fields</a>, that is, strings that contain data that is not human language, no language or direction metadata should be associated with the value. If a language tag is required for the data, the value <code>zxx</code> (Non-Linguistic) should be used. The direction of the text should be set to "auto".</p>
 		  
+  
 		  <aside class="example" title="Examples of non-linguistic string values">
 			  <pre class="javascript">
 "isbn": "978-123456789-X",
@@ -89,8 +96,11 @@
 		  
 		  <section id="single-linguistic-field">
 			  <h4>Single-Language Localizable Text Field</h4>
-		  <p>For <a>localizable text</a> fields that appear in a single language, use an object containing the value, language, and direction. A common serialization in JSON looks like this:</p>
+		  <p>For <a>localizable text</a> fields that appear in a single language, use a data structure to represent the value. The recommended representation is an object with three fields. The field <code>value</code> contains the actual string. The field <code>lang</code> contains a valid [[BCP47]] language tag. The field <code>dir</code> contains the string's <a>base direction</a> (one of the values <code>ltr</code>, <code>rtl</code>, or <code>auto</code>).</p>
 		  
+		  <p>See <a data-cite="STRING-META#use-the-localizable-data-structure">The Localizable WebIDL Dictionary</a> in [[STRING-META]].</p>
+		  
+		  <aside class="example" title="Example of a localizable text field">
 		  <pre class="json" id="localizable-text-field">
 "field-name-goes-here": {
     "value": "This is the string value",
@@ -98,41 +108,49 @@
     "dir": "ltr"
 }
 		  </pre>
+		  </aside>
 		  </section>
 		  
 		  <section id="language-defaults">
 			  <h4>Document-Level Defaults</h4>
 			  
-			  <p>Single-language localizable text fields are at their best if there are only a few natural language strings in a given document. When a document or manifest contains many natural language strings, this becomes inefficient. To reduce the complexity of encoding these strings, one workaround is to establish a document-level default for language and base direction. These are separate values, as language does not imply direction. There should still be the ability to override either value on any given string value by using the single-language <a>localizable text</a> field representation found <a href="#single-linguistic-field">above</a>.</p>
+			  <p>Single-language localizable text fields are at their best if there are only a few natural language strings in a given document. When a document such as a manifest contains many natural language strings, this becomes inefficient. To reduce the complexity of encoding these strings, one workaround is to establish a document-level default for language and base direction. These are separate values, as language does not imply direction. There should still be the ability to override either value on any given string value by using the single-language <a>localizable text</a> field representation found <a href="#single-linguistic-field">above</a>.</p>
 			  
 			  <p>For specifications that can make use of the [[JSON-LD]] <code>@context</code> mechanism, use the <code>@language</code> and <code>@direction</code> fields to supply the document level defaults.</p>
 			  
-			  <p>If your specification must define its own document level defaults, provide two optional fields. The document's default language field should be called <code>language</code> and can contain a valid [[BCP47]] language tag. The document's default base direction field should be called <code>direction</code> and support the values "ltr", "rtl", and "auto".</p>
+			  <p>If your specification must define its own document level defaults, provide two optional fields. The document's default language field should be called <code>language</code> and can contain a valid [[BCP47]] language tag. The document's default <a>base direction</a> field should be called <code>direction</code> and support the values <code>ltr</code>, <code>rtl</code>, or <code>auto</code>.</p>
 
-<pre class="javascript">
+              <aside class="example" title="Example of document level defaults">
+              <pre class="json">
 "language": "en-US",
 "direction": "ltr",
 //...
-"name": "This string is in U.S. English",
+"some-field-name": "This string is in U.S. English, thanks to the default",
 // the following field overrides the language but not the direction:
-"description": {
-   "value": "Diese Zeichenfolge ist auf Englisch",
+"another-field-name": {
+   "value": "Diese Zeichenfolge ist auf Deutsch",
    "lang": "de"
 }
-</pre>
+              </pre>
+              </aside>
+              
+              <aside class="note">
+				  <p><strong>Document level defaults are not a complete solution on their own.</strong> Specifications can define a document-level defaulting mechanism to assist users who often create monolingual documents. They are particularly useful when used in conjunction with the <a href="#locale-specific">locale-specific</a> or <a href="#hybrid">hybrid</a> approaches described later in this document. However, document-level defaults should only be used to augment the ability for users to provide string-specific metadata.</p>
+              </aside>
 		  </section>
 		  
 		  
 		  <section id="language-maps">
-			  <h4>Language Maps</h4>
+		  <h4>Language Maps</h4>
+		  
 		  <p>The world is not monolingual. Having documents that contain only a single language would mean providing many iterations of the document, one for each language, in order to localize the manifest. This also might require language negotiation when requesting the manifest.</p>
 		  
-		  <p>One way to address this is to allow multilingual values for a field inside the manifest document.</p>
+		  <p>One way to address this is to allow multilingual values for each <a>localizable text</a> field inside the manifest document.</p>
 		  
 		  <p>Language selection is not merely the exact matching of language tag string values to the user's preferred locale. The usual <a href="#localizable-text-field">object representation</a> of a <a>localizable text</a> field requires that the object be deserialized in order to discover the language tag associated with the value. This can be inefficient when there are many values in a given manifest file. In these cases, the best practice is to use a language map to organize <a>localizable text</a> values. Such a map exposes the language tag for the purposes of selection, but still uses an object representation on the value side of the map, since both language and direction might need to be overridden for a given string value.</p>
 		  
 		  <aside class="note">
-			  <p>The language map presented in this section is not the same as the language maps found in [[JSON-LD]] or [[JSON-SCHEMA]].</p>
+			  <p>The language map structure presented in this section is not the same as the language maps found in <a data-cite="JSON-LD#string-internationalization">JSON-LD String Internationalization</a> [[JSON-LD]].</p>
 		  </aside>
 		  
 		  <aside class="example" title="A localizable language map">

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
 		  
 		  <p>Natural language values stored in a manifest, like any document format or data structure, require language and direction metadata in order to be used by <a>consumers</a> successfully. For detailed information about the requirements, see [[STRING-META]].</p>
 		  
-		  <p>There are three common serializations for string values in a manifest:</p>
+		  <p>There are four common serializations for string values in a manifest in the following sections. These are generally used together to form a complete localization solution.</p>
 		  
 		  <section id="non-linguistic">
 			  <h4>Non-Linguistic Fields</h4>

--- a/index.html
+++ b/index.html
@@ -60,7 +60,6 @@
           <p><dfn data-lt="packaged" class="lint-ignore export">Packaged Manifest.</dfn> Some manifests are packaged with other files to form an application or document. Since the manifest is generally consumed as part of the larger set of content and the content is downloaded as a single unit, manifests of this type can use more modular localization strategies, such as using multiple files with names or paths based on the locale.</p>
           
           <p><dfn data-lt="shorthand" class="lint-ignore export">Shorthand Description Manifest.</dfn> Some manifests are meant to be used as a shorthand description of an application, document, or other resource. Manifests of this type are often downloaded by the client, sometimes as a precursor to retrieving the actual resource or its component parts. Since retrieving multiple files has latency, size, and storage implications, this type of manifest usually seeks to use a single file or other less-modular approaches.</p>
-      </section>
 
       <section id="language-preferences">
 		  <h2>Managing Language Preferences</h2>
@@ -72,18 +71,24 @@
           <p>Manifests need to match a user's language preference to the available localized resources. The user's locale preference can include more than just a primary language subtag. It might include the script (in tags such as <code>zh-Hans</code>, meaning "Chinese as written in the Simplified Han script") or region (in tags such as <code>fr-CA</code>, meaning "French as used in Canada")&mdash;or both. Some systems support <a>Unicode Locale Identifiers</a>, an extension to [[BCP47]] that includes tailoring such as calendars, number shaping, collation, and more. For more information, see [[LTLI]].</p>
           
           <p>Matching localized resources to a user's locale preference usually involves "locale fallback", using a mechanism such as [[BCP47]]'s "lookup" matching scheme or [[CLDR]]'s "best match" scheme. These involve comparing the language tags on each resource seeking the <em>longest</em> tag that completely matches the user's preference. There is also, usually, a default locale to use for cases in which none of the localized resources match the user's preference.</p>
+          
+          <p class="issue">Include an example showing how fallback works so readers understand why matching requires looking at the complete collection of resources.</p>
+      </section>
       </section>
       
-      <section id="">
+      <section id="indicating">
 		  <h2>Indicating Language and Direction</h2>
 		  
 		  <p><a>Natural language</a> values stored in a manifest, like any document format or data structure, require language and direction metadata in order to be used by <a>consumers</a> successfully. For detailed information about the requirements, see [[STRING-META]].</p>
 		  
-		  <p>There are four common serializations for string values in a manifest in the following sections. These are generally used together to form a complete localization solution.</p>
+		  <p>There are four common serializations for string values in a manifest, and these are described in this section. Specifications are intended to use these together to form a complete localization solution.</p>
 		  
 		  <section id="non-linguistic">
-			  <h4>Non-Linguistic Fields</h4>
-		  <p>For <a>non-linguistic fields</a>, that is, strings that contain data that is not human language, no language or direction metadata should be associated with the value. If a language tag is required for the data, the value <code>zxx</code> (Non-Linguistic) should be used. The direction of the text should be set to "auto".</p>
+		  <h4>Non-Linguistic Fields</h4>
+			  
+		  <p>For <a>non-linguistic fields</a> (that is, strings that contain data that is not human language) language or direction metadata SHOULD NOT be associated with the value. Note that this includes <a data-cite="international-specs/#application_internal">application-internal data values</a> [[INTERNATIONAL-SPECS]].</p>
+		  
+		  <p>If a <a>consumer</a> is required to assign a language tag to the data, the value <code>zxx</code> (Non-Linguistic) SHOULD be used. If a <a>consumer</a> is required to assign a <a>base direction</a> to the data, the value <code>auto</code> SHOULD be used.</p>
 		  
   
 		  <aside class="example" title="Examples of non-linguistic string values">
@@ -118,7 +123,12 @@
 			  
 			  <p>For specifications that can make use of the [[JSON-LD]] <code>@context</code> mechanism, use the <code>@language</code> and <code>@direction</code> fields to supply the document level defaults.</p>
 			  
-			  <p>If your specification must define its own document level defaults, provide two optional fields. The document's default language field should be called <code>language</code> and can contain a valid [[BCP47]] language tag. The document's default <a>base direction</a> field should be called <code>direction</code> and support the values <code>ltr</code>, <code>rtl</code>, or <code>auto</code>.</p>
+			  <p>If your specification defines its own document level defaults, provide two optional fields:</p>
+			  
+			  <ul>
+				  <li>The document's default language field SHOULD be called <code>language</code> and SHOULD be specified to contain a valid [[BCP47]] language tag. Specifications SHOULD specify that implementations are only require to check if a [[BCP47]] language tag is "well-formed".</li>
+				  <li>The document's default <a>base direction</a> field SHOULD be called <code>direction</code> and support the values <code>ltr</code>, <code>rtl</code>, or <code>auto</code>.</li>
+		      </ul>
 
               <aside class="example" title="Example of document level defaults">
               <pre class="json">
@@ -153,6 +163,7 @@
 			  <p>The language map structure presented in this section is not the same as the language maps found in <a data-cite="JSON-LD#string-internationalization">JSON-LD String Internationalization</a> [[JSON-LD]].</p>
 		  </aside>
 		  
+		  
 		  <aside class="example" title="A localizable language map">
 		  <pre class="json">
 "field-name-goes-here": {
@@ -162,6 +173,21 @@
     "ar":    {"value": "هذه عربية", "dir": "rtl"}
 }
 		  </pre>
+		  </aside>
+		  
+		  <aside class="note">
+			  <p>This structure permits a language tag as the key and also as part of the value. These two values do not have to match. The value of the key indicates the <a>locale</a> of the intended audience, while the language tag of the value represents information about the actual language of the string.</p>
+			  <p>These values might not match in cases where additional specificity is needed to get the correct rendering or processing of the value or, occasionally, when a foreign language value <strong><em>is</em></strong> the intended localization (and the language needs to be overridden, such as to select voices or dictionaries in assistive technology):</p>
+			  <pre class="json">
+"extra-rendering-help": {
+	"zh": {"value": "你好世界！", "lang": "zh-Hans"}
+}
+				  
+"hello-in-french": {
+	"en": {"value": "Bonjour!", "lang": "fr"},
+	"de": {"value": "Bonjour!", "lang": "fr"}
+}
+			  </pre>
 		  </aside>
 		  </section>
 		  

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
           shortName:  "localizable-manifests",
           editors: [
                 {   name:       "Addison Phillips",
-                    company:    "Amazon.com" , w3cid: 33573
+                    company:    "Invited Export" , w3cid: 33573
 	            }
           ],
           // if you wish the publication date to be other than today, set this

--- a/index.html
+++ b/index.html
@@ -87,13 +87,17 @@
 }
 			  </pre>
 			  
-			  <p>If the user's locale preference were <code>en-GB</code> or <code>en-US</code>, the best match is included in the list. Obviously, the entire list must be read to find the best match, since the entry for <code>en</code> also matches either value.</p>
+			  <p>If the user's <a>locale</a> preference were <code>en-GB</code> or <code>en-US</code>, the best match is included in the list. Obviously, the entire list must be read to find the best match, since the entry for <code>en</code> could be considered a match for either value.</p>
 			  
-			  <p>If the user's locale preference were <code>en-AE</code> (English as used in the United Arab Emirates), the best match in the list is <code>en</code>, although some implementations of best matching will apply out-of-band information to potentially match a longer tag.</p>
+			  <p>If the user's locale preference were <code>en-AE</code> (English as used in the United Arab Emirates), the best match in the list is <code>en</code>, although some implementations of best matching might apply out-of-band information to potentially match a longer tag.</p>
 			  
-			  <p>If the user's locale preference were <code>fr-FR</code> (French as used in France), none of the values match and some form of defaulting would be need to select the language to use.</p>
+			  <p>If the user's locale preference were <code>fr-FR</code> (French as used in France), none of the values match and some form of defaulting would be needed to select the value to use.</p>
 			  
-			  <p>Finally, the user's locale preference could include additional subtags, such as those used to tailor locale setting or such as a language variant. An example of a tailored locale might be <code>en-US-u-hc-h23</code> (US English but with the "hour cycle" set to 24 hour time). For more information on CLDR locale extensions, see [[RFC6067]]. An example of a language variant might be <code>en-GB-oxendict</code> (UK English, but using spelling conventions of the Oxford English Dictionary).</p>
+			  <p>Finally, the user's locale preference could include additional subtags, such as those used to tailor locale settings or such as a language variant. An example of a tailored locale might be <code>en-US-u-hc-h23</code> (US English but with the "hour cycle" set to 24 hour time). An example of a language variant might be <code>en-GB-oxendict</code> (UK English, but using spelling conventions of the Oxford English Dictionary).</p>
+			  
+			  <aside class="note">
+				  <p>For more information about CLDR locale extensions, see [[RFC6067]] or <a href="https://cldr.unicode.org/index/bcp47-extension">Unicode Extensions for BCP47</a> on the Unicode site.</p>
+			  </aside>
 			  
 			  <p>Locale fallback is implemented such that the user's preference is matched against the available list of values, and, if no exact match is found, removing the last subtag and repeating. This is described as "lookup" in the language tag matching part of [[BCP47]] (specifically [[RFC4647]]). Thus, the tag <code>en-GB-oxendict</code> would be compared against the above languge map as follows:</p>
 			  

--- a/index.html
+++ b/index.html
@@ -20,7 +20,8 @@
           //previousPublishDate:  "2021-08-24",
 		  noRecTrack: true,
           group:  "i18n",
-          github: "w3c/localizable-manifests"
+          github: "w3c/localizable-manifests",
+          xref: [ "i18n-glossary" ]
      };
 
     </script>
@@ -56,14 +57,99 @@
 		  <h2>Requirements and Use Cases</h2>
 		  <p>There are different ways that manifest files might be used on the Web and these affect the choice of manifest localization strategy.</p> 
 
-          <p><dfn data-lt="packaged">Packaged Manifest.</dfn> Some manifests are packaged with other files to form an application or document. Since the manifest is generally consumed as part of the larger set of content and the content is downloaded as a single unit, localization strategies that are modular, consisting of multiple files, are easier to use.</p>
+          <p><dfn data-lt="packaged" class="lint-ignore export">Packaged Manifest.</dfn> Some manifests are packaged with other files to form an application or document. Since the manifest is generally consumed as part of the larger set of content and the content is downloaded as a single unit, manifests of this type can use more modular localization strategies, such as using multiple files with names or paths based on the locale.</p>
           
-          <p><dfn data-lt="shorthand">Shorthand Description Manifest.</dfn> Other manifests are meant to be used as a shorthand description of the document or application. Manifests like this are often downloaded by the client: retrieving multiple files has latency, size, and storage implications that point toward fewer files or less modular approaches.</p>
+          <p><dfn data-lt="shorthand" class="lint-ignore export">Shorthand Description Manifest.</dfn> Some manifests are meant to be used as a shorthand description of an application, document, or other resource. Manifests of this type are often downloaded by the client, sometimes as a precursor to retrieving the actual resource or its component parts. Since retrieving multiple files has latency, size, and storage implications, this type of manifest usually seeks to use a single file or other less-modular approaches.</p>
 
-          <p>Another consideration is the <a href="https://www.w3.org/TR/i18n-glossary/#dfn-language-negotiation">language negotiation</a> strategy employed by the specification.</p>
+          <p>Another consideration is the <a href="https://www.w3.org/TR/i18n-glossary/#dfn-language-negotiation">language negotiation</a> strategy employed by the specification. If a manifest can be generated on demand (rather than being cached at a well-known URL), then the localization might be applied on a per-request basis. This points more toward a <a>shorthand</a> manifest style. In other cases, where some implementations might be able to negotiate while others cannot, it is important for the specification not to limit the choice and allow for various different mechanisms to be used.</p>
           
-          <p>Bear in mind that modern operating environments support quite extensive sets of available locales and that application owners often wish to satisfy diverse audiences with a single localized application or document. While examples in specifications necessarily are constrained to maybe three or four locales, actual applications with 50 or more specific locales are not uncommon.</p>
+          <p>Bear in mind that modern operating environments support quite extensive sets of available locales and that application owners often wish to satisfy diverse audiences with a single localized application or document. While examples in specifications necessarily are constrained to perhaps three or four locales, actual applications with 50 or more specific locales are not uncommon.</p>
+          
+          <p>In addition, users often have "overspecified" locales containing tailorings that match a given users local needs. Long locale identifiers, which are expressed as BCP47 language tags, sometimes need to be trimmed or have extensions removed when searching for localized resources (such as a manifest).</p>
       </section>
+      
+      <section id="">
+		  <h2>Indicating Language and Direction</h2>
+		  
+		  <p>Natural language values stored in a manifest, like any document format or data structure, require language and direction metadata in order to be used by <a>consumers</a> successfully. For detailed information about the requirements, see [[STRING-META]].</p>
+		  
+		  <p>There are three common serializations for string values in a manifest:</p>
+		  
+		  <section id="non-linguistic">
+			  <h4>Non-Linguistic Fields</h4>
+		  <p>For <a>non-linguistic fields</a>, that is, strings that contain data that is not human language, no language or direction metadata should be associated with the value. If a language tag is required for the data, the value <code>zxx</code> (Non-Linguistic) should be used. The direction of the text should be set to "auto".</p>
+		  
+		  <aside class="example" title="Examples of non-linguistic string values">
+			  <pre class="javascript">
+"isbn": "978-123456789-X",
+"part-number": "&#xa7;ABC-123-0094"
+			  </pre>
+		  </aside>
+		  </section>
+		  
+		  <section id="single-linguistic-field">
+			  <h4>Single-Language Localizable Text Field</h4>
+		  <p>For <a>localizable text</a> fields that appear in a single language, use an object containing the value, language, and direction. A common serialization in JSON looks like this:</p>
+		  
+		  <pre class="json" id="localizable-text-field">
+"field-name-goes-here": {
+    "value": "This is the string value",
+    "lang": "en-US",
+    "dir": "ltr"
+}
+		  </pre>
+		  </section>
+		  
+		  <section id="language-defaults">
+			  <h4>Document-Level Defaults</h4>
+			  
+			  <p>Single-language localizable text fields are at their best if there are only a few natural language strings in a given document. When a document or manifest contains many natural language strings, this becomes inefficient. To reduce the complexity of encoding these strings, one workaround is to establish a document-level default for language and base direction. These are separate values, as language does not imply direction. There should still be the ability to override either value on any given string value by using the single-language <a>localizable text</a> field representation found <a href="#single-linguistic-field">above</a>.</p>
+			  
+			  <p>For specifications that can make use of the [[JSON-LD]] <code>@context</code> mechanism, use the <code>@language</code> and <code>@direction</code> fields to supply the document level defaults.</p>
+			  
+			  <p>If your specification must define its own document level defaults, provide two optional fields. The document's default language field should be called <code>language</code> and can contain a valid [[BCP47]] language tag. The document's default base direction field should be called <code>direction</code> and support the values "ltr", "rtl", and "auto".</p>
+
+<pre class="javascript">
+"language": "en-US",
+"direction": "ltr",
+//...
+"name": "This string is in U.S. English",
+// the following field overrides the language but not the direction:
+"description": {
+   "value": "Diese Zeichenfolge ist auf Englisch",
+   "lang": "de"
+}
+</pre>
+		  </section>
+		  
+		  
+		  <section id="language-maps">
+			  <h4>Language Maps</h4>
+		  <p>The world is not monolingual. Having documents that contain only a single language would mean providing many iterations of the document, one for each language, in order to localize the manifest. This also might requires language negotiation at the document request level.</p>
+		  
+		  <p>One way to address this is to allow multilingual values for a field inside the manifest document.</p>
+		  
+		  <p>Language selection is not merely the exact matching of language tag string values to the user's preferred locale. The usual <a href="#localizable-text-field">object representation</a> of a <a>localizable text</a> field requires that the object be deserialized in order to discover the language tag associated with the value. This can be inefficient when there are many values in a given manifest file. In these cases, the best practice is to use a language map to organize <a>localizable text</a> values. Such a map exposes the language tag for the purposes of selection, but still uses an object representation on the value side of the map, since both language and direction might need to be overridden for a given string value.</p>
+		  
+		  <aside class="note">
+			  <p>The language map presented in this section is not the same as the language maps found in [[JSON-LD]] or [[JSON-SCHEMA]].</p>
+		  </aside>
+		  
+		  <aside class="example" title="A localizable language map">
+		  <pre class="json">
+"field-name-goes-here": {
+    "en":    {"value": "This is English"},
+    "en-GB": {"value": "This is UK English", "dir": "ltr"},
+    "fr":    {"value": "C'est français", "lang": "fr-CA", "dir": "ltr"},
+    "ar":    {"value": "هذه عربية", "dir": "rtl"}
+}
+		  </pre>
+		  </aside>
+		  </section>
+		  
+      </section>
+      
+      
       <section id="common-approaches">
 		  <h2>Common Approaches</h2>
 		  <p>There are several common approaches to creating localized manifests. Each offers certain advantages (and suffers from certain drawbacks):</p>
@@ -79,16 +165,16 @@
    "releaseDate": "2021-06-07",
    "releaseUrl": "https://example.com/path/to/myApplication",
 
-   // localizable values
+   // localizable values in a map
    "title": {
-       "en": "My Application",  // English
-       "fr": "Mon application", // French
-       "de": "Mein Bewerbund",  // German
-       "zh-Hans": "我的应用程序"  // Simplified Chinese
+       "en": {"value": "My Application"},                   // English
+       "fr": {"value": "Mon application", "lang": "fr-CA"}, // French
+       "de": {"value": "Mein Bewerbund"},                   // German
+       "zh-Hans": {"value": "我的应用程序"}                   // Simplified Chinese
    },
    "author": {
-       "en": "Example Corporation",
-       "fr": "Société Exemple"
+       "en": {"value": "Example Corporation"},
+       "fr": {"value": "Société Exemple"}
    }</pre>
 			  </aside>
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
           shortName:  "localizable-manifests",
           editors: [
                 {   name:       "Addison Phillips",
-                    company:    "Invited Export" , w3cid: 33573
+                    company:    "Invited Expert" , w3cid: 33573
 	            }
           ],
           // if you wish the publication date to be other than today, set this
@@ -61,7 +61,7 @@
           
           <p><dfn data-lt="shorthand" class="lint-ignore export">Shorthand Description Manifest.</dfn> Some manifests are meant to be used as a shorthand description of an application, document, or other resource. Manifests of this type are often downloaded by the client, sometimes as a precursor to retrieving the actual resource or its component parts. Since retrieving multiple files has latency, size, and storage implications, this type of manifest usually seeks to use a single file or other less-modular approaches.</p>
 
-          <p>Another consideration is the <a href="https://www.w3.org/TR/i18n-glossary/#dfn-language-negotiation">language negotiation</a> strategy employed by the specification. If a manifest can be generated on demand (rather than being cached at a well-known URL), then the localization might be applied on a per-request basis. This points more toward a <a>shorthand</a> manifest style. In other cases, where some implementations might be able to negotiate while others cannot, it is important for the specification not to limit the choice and allow for various different mechanisms to be used.</p>
+          <p>Another consideration is the <a>language negotiation</a> strategy employed by the specification. If a manifest can be generated on demand (rather than being cached at a well-known URL), then the localization might be applied on a per-request basis. This points more toward a <a>shorthand</a> manifest style. In other cases, where some implementations might be able to negotiate while others cannot, it is important for the specification not to limit the choice and allow for various different mechanisms to be used.</p>
           
           <p>Bear in mind that modern operating environments support quite extensive sets of available locales and that application owners often wish to satisfy diverse audiences with a single localized application or document. While examples in specifications necessarily are constrained to perhaps three or four locales, actual applications with 50 or more specific locales are not uncommon.</p>
           

--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@ en              // if en-GB were not present, matches en
 			  <p>If your specification defines its own document level defaults, provide two optional fields:</p>
 			  
 			  <ul>
-				  <li>The document's default language field SHOULD be called <code>language</code> and SHOULD be specified to contain a <a>valid</a> [[BCP47]] language tag. Specifications SHOULD specify that implementations are only require to check if a [[BCP47]] language tag is <a>well formed</a>.</li>
+				  <li>The document's default language field SHOULD be called <code>language</code> and SHOULD be specified to contain a <a>valid</a> [[BCP47]] language tag. Specifications SHOULD specify that implementations are only require to check if a [[BCP47]] language tag is <a>well-formed</a>.</li>
 				  <li>The document's default <a>base direction</a> field SHOULD be called <code>direction</code> and support the values <code>ltr</code>, <code>rtl</code>, or <code>auto</code>.</li>
 		      </ul>
 

--- a/index.html
+++ b/index.html
@@ -96,7 +96,17 @@
 "isbn": "978-123456789-X",
 "part-number": "&#xa7;ABC-123-0094"
 			  </pre>
+			  
+			  <p>Note that non-linguistic values are sometimes <em>localized</em>, even though they are not <em>translated</em>.</p>
+			  <pre class="javascript">
+"gaining-value-color": "green", // perhaps "red" in another locale?
+"background-color": "#ffebdd",  // or something else?
+"default-level": "medium",      // perhaps "large" or "small" in another locale?
+"help-file-url": "https://example.org/en-US/help.html"
+			  </pre>
 		  </aside>
+		  
+
 		  </section>
 		  
 		  <section id="single-linguistic-field">

--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
 		  
 		  <section id="language-maps">
 			  <h4>Language Maps</h4>
-		  <p>The world is not monolingual. Having documents that contain only a single language would mean providing many iterations of the document, one for each language, in order to localize the manifest. This also might requires language negotiation at the document request level.</p>
+		  <p>The world is not monolingual. Having documents that contain only a single language would mean providing many iterations of the document, one for each language, in order to localize the manifest. This also might require language negotiation when requesting the manifest.</p>
 		  
 		  <p>One way to address this is to allow multilingual values for a field inside the manifest document.</p>
 		  

--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@ en              // if en-GB were not present, matches en
 		  
 		  <section id="single-linguistic-field">
 			  <h4>Single-Language Localizable Text Field</h4>
-		  <p>For <a>localizable text</a> fields that appear in a single language, use a data structure to represent the value. The recommended representation is an object with three fields. The field <code>value</code> contains the actual string. The field <code>lang</code> contains a valid [[BCP47]] language tag. The field <code>dir</code> contains the string's <a>base direction</a> (one of the values <code>ltr</code>, <code>rtl</code>, or <code>auto</code>).</p>
+		  <p>For <a>localizable text</a> fields that appear in a single language, use a data structure to represent the value. The recommended representation is an object with three fields. The field <code>value</code> contains the actual string. The field <code>lang</code> contains a <a>valid</a> [[BCP47]] language tag. The field <code>dir</code> contains the string's <a>base direction</a> (one of the values <code>ltr</code>, <code>rtl</code>, or <code>auto</code>).</p>
 		  
 		  <p>See <a data-cite="STRING-META#use-the-localizable-data-structure">The Localizable WebIDL Dictionary</a> in [[STRING-META]].</p>
 		  
@@ -172,7 +172,7 @@ en              // if en-GB were not present, matches en
 			  <p>If your specification defines its own document level defaults, provide two optional fields:</p>
 			  
 			  <ul>
-				  <li>The document's default language field SHOULD be called <code>language</code> and SHOULD be specified to contain a valid [[BCP47]] language tag. Specifications SHOULD specify that implementations are only require to check if a [[BCP47]] language tag is "well-formed".</li>
+				  <li>The document's default language field SHOULD be called <code>language</code> and SHOULD be specified to contain a <a>valid</a> [[BCP47]] language tag. Specifications SHOULD specify that implementations are only require to check if a [[BCP47]] language tag is <a>well formed</a>.</li>
 				  <li>The document's default <a>base direction</a> field SHOULD be called <code>direction</code> and support the values <code>ltr</code>, <code>rtl</code>, or <code>auto</code>.</li>
 		      </ul>
 


### PR DESCRIPTION
Address w3c/i18n-actions#58

Updating localizable-manifests to reflect our work with the app-manifest folks at TPAC and subsequent work on various formats.

This involves extensive additions to the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aphillips/localizable-manifests/pull/16.html" title="Last updated on Nov 30, 2023, 4:11 PM UTC (26e7f78)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/localizable-manifests/16/7025e7c...aphillips:26e7f78.html" title="Last updated on Nov 30, 2023, 4:11 PM UTC (26e7f78)">Diff</a>